### PR TITLE
支持隐藏文件夹与文件

### DIFF
--- a/index.php
+++ b/index.php
@@ -343,6 +343,7 @@ function handleRequest($url, $returnUrl = false, $requestForFile = false)
 				handleFile($data["@microsoft.graph.downloadUrl"], $data);/*下载文件*/
 			}
 		} else if (array_key_exists('value', $data)) {/*返回的是目录*/
+			if (strpos($path, '/.') !== false) die('Access denied');/*阻止.开头的文件夹列出目录*/
 			/*渲染目录,2021.11.11修复空目录返回空白的bug*/
 			$render = renderFolderIndex(($data['value'] ? $data['value'] : []), parsePath($url));
 			return $render;
@@ -514,6 +515,7 @@ function renderFolderIndex($items, $isIndex)
 		$jsonArr['msg'] = 'Password required,please post the form: requestfolder=' . $folderMd5 . '&password=<thepassword>';
 	} else {
 		foreach ($items as $v) {
+			if (substr($v['name'], 0, 1) == '.') continue;
 			if (isset($v['folder'])) {/*是目录*/
 				$jsonArr['folders'][] = ['createdDateTime' => $v['createdDateTime'], 'lastModifiedDateTime' => $v['lastModifiedDateTime'], 'name' => $v['name'], 'size' => $v['size'], 'link' => processHref($v['name'] . '/')];
 				$itemRender .= item("folder", $v['name'], $v, $v['size'], processHref($v['name'] . '/'));

--- a/index.php
+++ b/index.php
@@ -33,7 +33,7 @@ $config = array(
 	'thumbnail' => true,
 	'preview' => true,
 	'max_preview_size' => 314572, /*最大支持预览的文件大小(in bytes)*/
-	'preview_suffix' => ['ogg', 'mp3', 'wav', 'm4a', 'mp4', 'webm', 'jpg', 'jpeg', 'png', 'gif', 'webp', 'md', 'markdown', 'txt', 'docx', 'pptx', 'xlsx', 'doc', 'ppt', 'xls', 'js', 'html', 'json', 'css'],/*可预览的类型,只少不多*/
+	'preview_suffix' => ['flac', 'ogg', 'mp3', 'wav', 'm4a', 'mp4', 'webm', 'jpg', 'jpeg', 'png', 'gif', 'webp', 'md', 'markdown', 'txt', 'docx', 'pptx', 'xlsx', 'doc', 'ppt', 'xls', 'js', 'html', 'json', 'css'],/*可预览的类型,只少不多*/
 	'use_proxy' => false,
 	'proxy_path' => false, /*代理程序url，false则用本目录下的*/
 	'no_index' => false, /*关闭列表*/
@@ -666,6 +666,7 @@ function handlePreview($url, $data)
 			case 'mp3':
 			case 'wav':
 			case 'm4a':
+			case 'flac':
 				$previewContent = getTp('audiopreview');
 				break;
 			default:

--- a/index.php
+++ b/index.php
@@ -289,6 +289,13 @@ function jump2folder()
 	global $config, $pathQuery;
 	header('Location: ' . ($config['rewrite'] ? ($config['site_path'] . '/' . $pathQuery . '/') : '?/' . $pathQuery . '/'));/*如果是目录，没有带/的就跳转到有/的*/
 }
+function zme404()
+{
+	http_response_code(404);/*找不到文件就返回404，以便处理2021.11.11*/
+	$jsonArr['msg'] = 'Not found: ' . urldecode($path);
+	echo ($config['list_as_json'] ? json_encode($jsonArr, true) : '<!--NotFound:' . urldecode($path) . '-->');
+	return '';/*当文件或目录不存在的时候返回空，以免缓存记录*/
+}
 function handleRequest($url, $returnUrl = false, $requestForFile = false)
 {
 	global $config, $ifRequestFolder;
@@ -335,7 +342,7 @@ function handleRequest($url, $returnUrl = false, $requestForFile = false)
 		$data = json_decode($resp, true);
 		if (isset($data['file'])) {/*返回的是文件*/
 			if ($returnUrl) return $data["@microsoft.graph.downloadUrl"];/*如果returnUrl=true就直接返回Url，用于取得文件内容*/
-			if ($data['name'] == $config['pwd_cfg_path']) die('Access denied');/*阻止密码文件被获取到*/
+			if ($data['name'] == $config['pwd_cfg_path']) return zme404();/*阻止密码文件被获取到*/
 			if (ifCacheStart() && !$cache) cacheControl('write', $url, array($resp));/*只有下载链接储存缓存*/
 			if ($preview == 't') {/*预览模式*/
 				return handlePreview($data["@microsoft.graph.downloadUrl"], $data);/*渲染预览*/
@@ -343,8 +350,8 @@ function handleRequest($url, $returnUrl = false, $requestForFile = false)
 				handleFile($data["@microsoft.graph.downloadUrl"], $data);/*下载文件*/
 			}
 		} else if (array_key_exists('value', $data)) {/*返回的是目录*/
-			if (strpos($path, '/.') !== false) die('Access denied');/*阻止.开头的文件夹列出目录*/
-			/*渲染目录,2021.11.11修复空目录返回空白的bug*/
+            if (strpos($path, '/.') !== false) return zme404();/*阻止.开头的文件夹列出目录*/
+            /*渲染目录,2021.11.11修复空目录返回空白的bug*/
 			$render = renderFolderIndex(($data['value'] ? $data['value'] : []), parsePath($url));
 			return $render;
 		} else if (array_key_exists('folder', $data)) {/*没有value，但有目录，说明url末尾没有加/*/
@@ -357,10 +364,7 @@ function handleRequest($url, $returnUrl = false, $requestForFile = false)
 	} else if ($config['no_index']) {
 		return $config['no_index_print'];
 	} else {
-		http_response_code(404);/*找不到文件就返回404，以便处理2021.11.11*/
-		$jsonArr['msg'] = 'Not found: ' . urldecode($path);
-		echo ($config['list_as_json'] ? json_encode($jsonArr, true) : '<!--NotFound:' . urldecode($path) . '-->');
-		return '';/*当文件或目录不存在的时候返回空，以免缓存记录*/
+		return zme404();
 	}
 }
 function item($icon, $fileName, $rawData = false, $size = false, $href = false)


### PR DESCRIPTION
写了一个功能，你看看有没有必要合进去，这样可以存放一些公开发布的文件以供下载，但不能被全部爬走  
如果文件名或目录名以"."开头，比如".config"，这个文件或目录就不会出现在列表中，但是可以直接以完整的文件名打开
当一个目录的文件名为"."开头，那将不允许浏览这个目录内的文件列表（返回Access denied），但是如果拥有完整的路径，文件依然可以访问，举例：  
/media/.video/2023/1.mp4  
可以浏览/media中的内容，但.video文件夹不会出现   
/media/.video和/media/.video/2023的文件列表不可以被浏览（返回Access denied）  
访问/media/.video/2023/1.mp4可以正常的下载文件
